### PR TITLE
Use JJWT BOM for consistent versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,24 @@
 	<name>TradeWave</name>
 	<description>Demo project for Spring Boot</description>
 
-	<properties>
-		<java.version>21</java.version>
-		<lombok.version>1.18.32</lombok.version>
-	</properties>
+        <properties>
+                <java.version>21</java.version>
+                <lombok.version>1.18.32</lombok.version>
+        </properties>
 
-	<dependencies>
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>io.jsonwebtoken</groupId>
+                                <artifactId>jjwt-bom</artifactId>
+                                <version>0.12.6</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
+
+        <dependencies>
 		<!-- Spring Starters -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -37,24 +49,21 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
-		<!-- JWT -->
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-api</artifactId>
-			<version>0.12.6</version>
-		</dependency>
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-impl</artifactId>
-			<version>0.12.6</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-jackson</artifactId>
-			<version>0.12.6</version>
-			<scope>runtime</scope>
-		</dependency>
+                <!-- JWT -->
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-api</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-impl</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-jackson</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
 
 		<!-- Lombok -->
 		<dependency>


### PR DESCRIPTION
## Summary
- Manage JJWT dependencies via `io.jsonwebtoken:jjwt-bom:0.12.6`
- Remove explicit versions from `jjwt-api`, `jjwt-impl`, and `jjwt-jackson`

## Testing
- ⚠️ `./mvnw -q dependency:list -DincludeGroupIds=io.jsonwebtoken | grep jjwt` (failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)
- ⚠️ `./mvnw -q test` (failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)


------
https://chatgpt.com/codex/tasks/task_e_68aeee860d188330af63ff20207a3a63