### PR TITLE
Use Spring Boot 3.3.5 parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.3</version>
+                <version>3.3.5</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
## Summary
- align project with an officially released Spring Boot parent (3.3.5)

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aeee872aa08330aa6ed1b57f634ef4