### PR TITLE
Replace Paths.get role extraction in JWT filter

### DIFF
--- a/src/main/java/com/murat/tradewave/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/murat/tradewave/security/JwtAuthenticationFilter.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static java.nio.file.Paths.get;
 
 @Component
 @RequiredArgsConstructor
@@ -98,8 +97,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         List<SimpleGrantedAuthority> authorities;
         try {
-            ;
-            authorities = mapRolesToAuthorities(get("roles"));
+            authorities = mapRolesToAuthorities(jwtService.extractRoles(token));
         } catch (ExpiredJwtException ex) {
             writeJsonError(response, HttpServletResponse.SC_UNAUTHORIZED, "TOKEN_EXPIRED", "JWT expired");
             SecurityContextHolder.clearContext();


### PR DESCRIPTION
## Summary
- Replace erroneous `Paths.get("roles")` call with `jwtService.extractRoles(token)` in `JwtAuthenticationFilter`
- Remove unused static `Paths.get` import

## Testing
- `mvn -q test` *(fails: Network is unreachable when resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68af300b96488330a6f8723795ec917e