### PR TITLE
Remove password field from user response DTO

### DIFF
--- a/src/main/java/com/murat/tradewave/dto/user/response/UserResponse.java
+++ b/src/main/java/com/murat/tradewave/dto/user/response/UserResponse.java
@@ -1,7 +1,6 @@
 package com.murat.tradewave.dto.user.response;
 
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,7 +9,6 @@ import lombok.Setter;
 public class UserResponse {
     private Long id;
     private String email;
-    private String password;
     private String name;
     private String token;
 }

--- a/src/main/java/com/murat/tradewave/helper/Mapper.java
+++ b/src/main/java/com/murat/tradewave/helper/Mapper.java
@@ -52,7 +52,6 @@ public UserResponse mapToUserResponse(User user){
                 .email(user.getEmail())
                 .name(user.getName())
                 .id(user.getId())
-                .password(user.getPassword())
                 .build();
 }
 public SellerRequest mapToSellerResponse(Seller seller){


### PR DESCRIPTION
## Summary
- remove password property from `UserResponse`
- stop including password in `Mapper.mapToUserResponse`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.murat: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af300abf288330a2a043f28a4357b3