### PR TITLE
Persist role change in UserImplService

### DIFF
--- a/src/main/java/com/murat/tradewave/service/UserImplService.java
+++ b/src/main/java/com/murat/tradewave/service/UserImplService.java
@@ -65,6 +65,7 @@ public class UserImplService implements UserService {
     public UserResponse changeRole(Long id,Role newRole){
         User changedRole = userRepository.findById(id).orElseThrow(()->new RuntimeException("user not found"));
         changedRole.setRole(newRole);
+        userRepository.save(changedRole);
         return mapper.mapToUserResponse(changedRole);
     }
 


### PR DESCRIPTION
## Summary
- Save role changes back to the database in `UserImplService.changeRole`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af3007d17c8330b97986552b041fc9