### PR TITLE
Reorder validation and mail dependencies in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,33 +80,34 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<!-- Devtools -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
+                <!-- Devtools -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-devtools</artifactId>
+                        <scope>runtime</scope>
+                        <optional>true</optional>
+                </dependency>
 
-		<!-- Test -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-mail</artifactId>
+                </dependency>
+
+                <!-- Test -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-mail</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
 
 	</dependencies>
 


### PR DESCRIPTION
## Summary
- Move `spring-boot-starter-validation` and `spring-boot-starter-mail` dependencies above the test block in `pom.xml`
- Ensure test dependencies only include `spring-boot-starter-test` and `spring-security-test`

## Testing
- `mvn test -q` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af301c326c8330a43412329bb0b05e